### PR TITLE
Added the permission "coarse location"

### DIFF
--- a/bluetooth-spp-terminal/src/main/AndroidManifest.xml
+++ b/bluetooth-spp-terminal/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
otherwise the discovery of new devices doesn't work,

see:
https://developer.android.com/reference/android/bluetooth/BluetoothDevice.html#ACTION_FOUND
